### PR TITLE
Improve screensaver drawing efficiency

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -80,9 +80,16 @@ typedef struct _MATRIX_COLUMN
 
 typedef struct _MATRIX
 {
-	// bitmap containing glyphs.
-	HDC hdc;
-	HBITMAP hbitmap;
+        // bitmap containing glyphs.
+        HDC hdc;
+        HBITMAP hbitmap;
+
+        // cached window dc and back-buffer for drawing
+        HDC hdc_window;
+        HDC hdc_back;
+        HBITMAP hbitmap_back;
+
+        INT current_hue;
 
 	ULONG width;
 	ULONG height;


### PR DESCRIPTION
## Summary
- cache window HDC and reuse it instead of calling `GetDC` every frame
- only recreate the glyph bitmap when hue changes
- draw each frame to an offscreen buffer and copy with a single `BitBlt`

## Testing
- `git commit -m "Optimize drawing by caching HDC"`

------
https://chatgpt.com/codex/tasks/task_e_683f5b299f1c832e9b05c32baefef57a