### PR TITLE
Fix PayPal donation link text

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Originally written by J Brown 2003.
 ### Donate:
 - [Bitcoin](https://www.blockchain.com/btc/address/1LrRTXPsvHcQWCNZotA9RcwjsGcRghG96c) (BTC)
 - [Ethereum](https://www.blockchain.com/explorer/addresses/eth/0xe2C84A62eb2a4EF154b19bec0c1c106734B95960) (ETH)
-- [Paypal](https://paypal.me/henrypp) (USD)
+- [PayPal](https://paypal.me/henrypp) (USD)
 - [Yandex Money](https://yoomoney.ru/to/4100115776040583) (RUB)
 
 ### GPG Signature:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Originally written by J Brown 2003.
 ### Donate:
 - [Bitcoin](https://www.blockchain.com/btc/address/1LrRTXPsvHcQWCNZotA9RcwjsGcRghG96c) (BTC)
 - [Ethereum](https://www.blockchain.com/explorer/addresses/eth/0xe2C84A62eb2a4EF154b19bec0c1c106734B95960) (ETC)
-- [Paypal](https://paypal.me/henrypp) (USD)
+- [PayPal](https://paypal.me/henrypp) (USD)
 - [Yandex Money](https://yoomoney.ru/to/4100115776040583) (RUB)
 
 ### GPG Signature:


### PR DESCRIPTION
## Summary
- correct the PayPal donation link text capitalization in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69012ca14204832eb66515f89f6ecd7a