### PR TITLE
Fix potential out-of-bounds read in matrix column scrolling

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -205,7 +205,8 @@ VOID ScrollMatrixColumn (
 				y++;
 		}
 
-		last_glyph = column->glyph[y];
+		if (y < (ULONG_PTR)column->length)
+			last_glyph = column->glyph[y];
 	}
 
         // change state from blanks <-> runs when the current run has expired


### PR DESCRIPTION
### Motivation
- Prevent a possible out-of-bounds read in `ScrollMatrixColumn` when the loop increments `y` to `column->length`, which could cause `column->glyph[y]` to be read past the end of the array.

### Description
- Add a boundary check before updating `last_glyph` so `last_glyph = column->glyph[y]` is executed only when `y < column->length` in `ScrollMatrixColumn`.
- Modified file: `src/main.c`.

### Testing
- Ran the test suite with `pytest -q`, which passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab5e792250832eb12cc0e93689519d)