### PR TITLE
Fix config dialog process not exiting on close

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -771,6 +771,7 @@ INT_PTR CALLBACK SettingsProc (
 		case WM_DESTROY:
 		{
 			SaveSettings ();
+			config.is_preview = FALSE;
 
 			PostQuitMessage (0);
 


### PR DESCRIPTION
## Summary
- fix the options/config dialog shutdown path to fully exit preview mode
- update `SettingsProc` `WM_DESTROY` in `src/main.c` to reset `config.is_preview` before posting quit

## Details
Closing the settings dialog destroyed the window and posted quit, but left `config.is_preview` set to `TRUE`. That could keep the process in an inconsistent state and allow it to linger in the background.

This change adds a minimal, safe reset in the existing destroy handler:
1. `SaveSettings();`
2. `config.is_preview = FALSE;`
3. `PostQuitMessage(0);`

No rendering paths or main loop structure were changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abfbceda7c832e8b45afb3d9178e16)