### PR TITLE
Fix process hang after closing configure dialog

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1041,7 +1041,10 @@ INT APIENTRY wWinMain (
 	}
 
 	if (hwnd)
+	{
 		_r_wnd_message_callback (hwnd, NULL);
+		goto CleanupExit;
+	}
 
 	while (GetMessageW (&msg, NULL, 0, 0) > 0)
 	{


### PR DESCRIPTION
When the settings dialog is closed, WM_QUIT is consumed by _r_wnd_message_callback's internal loop. Control then fell through to the outer GetMessageW loop which blocked forever since WM_QUIT had already been consumed and all windows were destroyed.

Add goto CleanupExit after _r_wnd_message_callback returns so the configure-dialog path skips the outer message loop entirely and exits cleanly. The /s fullscreen path is unaffected as it does not set hwnd the same way.
